### PR TITLE
Make CITATION cff valid

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -107,7 +107,12 @@ references:
         given-names: "Nicole M."
       - family-names: Bridger
         given-names: Alan
-    conference: "Society of Photo-Optical Instrumentation Engineers (SPIE)"
+    conference:
+      name: "Society of Photo-Optical Instrumentation Engineers (SPIE)"
+      city: San Diego
+      country: US
+      date-start: "2010-06-27"
+      date-end: "2010-07-02"
     volume: 7740
     month: 7
     edition: 77401A


### PR DESCRIPTION
Hi:

First of all, sorry for the direct approach. I am the author of the [cff-validator](https://github.com/dieghernan/cff-validator) GitHub Action when reviewing the performance of the action I found it gives a non-valid error on this repo.

This is due to the key:

```yaml
conference: "Society of Photo-Optical Instrumentation Engineers (SPIE)"
```
 
Note that `conference` should be a provided in the form of a list as per the [Guide to Citation File Format schema version 1.2.0](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreferenceconference) so the right definition for this needs to be:

```yaml
conference: 
  name: "Society of Photo-Optical Instrumentation Engineers (SPIE)"
```

I took the liberty of completing more fields (see the [definitions entity](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsentity) of the schema, that is the format that needs to be used on `conference`) with the information provided in [the front matter of the proceeding](https://www.spiedigitallibrary.org/conference-proceedings-of-spie/7740/1/Front-Matter-Volume-7740/10.1117/12.871473.full):

```yaml
    conference:
      name: "Society of Photo-Optical Instrumentation Engineers (SPIE)"
      city: San Diego
      country: US
      date-start: "2010-06-27"
      date-end: "2010-07-02"

```

Regards